### PR TITLE
Add Instagram settings, navigation and insights.

### DIFF
--- a/webapp/_lib/view/_navigation.tpl
+++ b/webapp/_lib/view/_navigation.tpl
@@ -6,9 +6,8 @@
   {if isset($logged_in_user)}
         <li class="service {$facebook_connection_status}"><a href="{$site_root_path}account/?p=facebook" {if $smarty.get.p eq 'facebook'}class="active"{/if}>Facebook<i class="fa fa-{if $facebook_connection_status eq 'active'}check-circle{elseif $facebook_connection_status eq 'error'}exclamation-triangle{else}facebook-square{/if} icon"></i></a></li>
         <li class="service {$twitter_connection_status}"><a href="{$site_root_path}account/?p=twitter" {if $smarty.get.p eq 'twitter'}class="active"{/if}>Twitter<i class="fa fa-{if $twitter_connection_status eq 'active'}check-circle{elseif $twitter_connection_status eq 'error'}exclamation-triangle{else}twitter{/if} icon"></i></a></li>
-        <!--
-        <li class="service inactive"><a href="{$site_root_path}account/?p=instagram">Instagram <i class="fa fa-instagram icon"></i></a></li>
-        -->
+
+        <li class="service {$instagram_connection_status}"><a href="{$site_root_path}account/?p=instagram" {if $smarty.get.p eq 'instagram'}class="active"{/if}>Instagram <i class="fa fa-{if $instagram_connection_status eq 'active'}check-circle{elseif $instagram_connection_status eq 'error'}exclamation-triangle{else}instagram{/if} icon"></i></a></li>
 
       {if !isset($thinkupllc_endpoint)}
 

--- a/webapp/_lib/view/insights.tpl
+++ b/webapp/_lib/view/insights.tpl
@@ -98,7 +98,7 @@
     </div>
     <div class="panel-footer">
       <div class="insight-metadata">
-        <i class="fa fa-{$i->instance->network}-square icon icon-network"></i>
+        <i class="fa fa-{$i->instance->network}{if ($i->instance->network neq 'instagram')}-square{/if} icon icon-network"></i>
         <a class="permalink" href="{$permalink}">{$i->date|date_format:"%b %e"}</a>
       </div>
       <div class="share-menu">

--- a/webapp/plugins/insightsgenerator/view/_post.tpl
+++ b/webapp/plugins/insightsgenerator/view/_post.tpl
@@ -11,7 +11,7 @@ $hide_avatar (optional) do not display the user's avatar, typically used if the 
   <a href="{if $post->network eq 'twitter'}https://twitter.com/intent/user?user_id={elseif $post->network eq 'facebook'}https://facebook.com/{/if}{$post->author_user_id}" title="{$post->author_username}"><img src="{$post->author_avatar|use_https}" alt="{$post->author_username}" width="60" height="60" class="img-circle pull-left tweet-photo user-photo"></a>
   <div class="byline"><a href="{if $post->network eq 'twitter'}https://twitter.com/intent/user?user_id={elseif $post->network eq 'facebook'}https://facebook.com/{/if}{$post->author_user_id}" title="{$post->author_username}"><strong>{$post->author_fullname}</strong> {if $post->network eq 'twitter'}<span class="username">@{$post->author_username}</span>{/if}</a></div>
   <div class="tweet-body">{$post->post_text|filter_xss|link_usernames_to_twitter}</div>
-{foreach from=$post->links item=l} 
+{foreach from=$post->links item=l}
   {if !isset($breakphotos) and isset($l->image_src) and $l->image_src neq ""}
   <div class="photo clearfix">
     <a href="{$l->url}"><img src="{$l->image_src}" class="photo_img" alt="Photo from {$post->author_fullname}"></a>
@@ -19,6 +19,11 @@ $hide_avatar (optional) do not display the user's avatar, typically used if the 
   {assign var="breakphotos" value="true"}
   {/if}
 {/foreach}
+{if isset($post->standard_resolution_url)}
+  <div class="photo clearfix">
+    <a href="{$post->permalink}"><img src="{$post->standard_resolution_url}" class="photo_img" alt="Photo from {$post->author_fullname}"></a>
+  </div>
+{/if}
   <div class="tweet-actions">
     <a href="{if $post->network eq 'twitter'}https://twitter.com/{$post->author_username}/status/{/if}{if
       $post->network eq 'facebook'}https://www.facebook.com/{$post->author_user_id}/posts/{/if}{$post->post_id}"

--- a/webapp/plugins/instagram/tests/TestOfInstagramPluginConfigurationController.php
+++ b/webapp/plugins/instagram/tests/TestOfInstagramPluginConfigurationController.php
@@ -466,6 +466,6 @@ class TestOfInstagramPluginConfigurationController extends ThinkUpUnitTestCase {
         $output = $controller->go();
         // looks for account delete token
         $this->assertPattern('/name="csrf_token" value="'. self::CSRF_TOKEN .
-        '" \/><!\-\- delete account csrf token \-\->/', $output);
+        '" \/>/', $output);
     }
 }

--- a/webapp/plugins/instagram/view/instagram.account.index.tpl
+++ b/webapp/plugins/instagram/view/instagram.account.index.tpl
@@ -1,151 +1,172 @@
-{include file="_usermessage.tpl"}
+  <div class="container">
+    <header class="container-header">
+      <h1>Instagram</h1>
+      <h2>Manage accounts and choose who can see insights.</h2>
+    </header>
 
-<div class="plugin-info">
-
-    <span class="pull-right">{insert name="help_link" id='instagram'}</span>
-    <h2>
-        <i class="icon-instagram icon-muted"></i> Instagram
-    </h2>
-
-</div>
-
-{if $instaconnect_link}
-{include file="_usermessage.tpl" field="authorization"}
-<a href="{$instaconnect_link}" class="btn btn-success add-account"><i class="icon-plus icon-white"></i> Add an Instagram User</a>
-{/if}
-
-{if count($instances) > 0 }{include file="_usermessage.tpl" field="user_add"}{/if}
-
-{if count($instances) > 0 }
-<div>
-    <h2>Users</h2>
-
-    {foreach from=$instances key=iid item=i name=foo}
-    <div class="row-fluid">
-        <div class="span3">
-            {if $i->auth_error}<span class="ui-icon ui-icon-alert" style="float: left; margin:0.25em 0 0 0;" id="instagram-auth-error"></span>{/if}
-            <a href="{$site_root_path}?u={$i->network_username|urlencode}&n={$i->network|urlencode}">{$i->network_username}</a>
+    {if count($instances) > 0 }
+    <ul class="list-group list-accounts form-horizontal">
+      {foreach from=$instances key=iid item=i name=foo}
+      <li class="list-group-item list-accounts-item{if !isset($thinkupllc_endpoint)} has-extra-buttons{/if}">
+        <div class="account-label">
+          {if $i->auth_error}<span class="fa fa-warning text-warning" id="instagram-auth-error"></span>{/if}
+          <img src="http://avatars.io/instagram/{$i->network_username}" class="account-photo img-circle">
+          <a href="https://instagram.com/{$i->network_username}">{$i->network_username}</a>
         </div>
-        <div class="span3">
-            <span id="div{$i->id}"><input type="submit" name="submit" id="{$i->id}" class="btn {if $i->is_public}btnPriv{else}btnPub{/if}" value="Set {if $i->is_public}private{else}public{/if}" /></span>
+        <div class="account-action account-action-privacy">
+          <div class="privacy-toggle fa-over" data-id="{$i->id}"
+            data-network="{$i->network}" data-network-name="{$i->network_username}">
+            <input type="radio" name="{$i->network_username}-privacy-toggle-control" value="0"
+            class="field-privacy-private"
+            {if not $i->is_public}checked="checked"{/if} id="field-{$i->network_username}-privacy-private" /><label class="toggle-label" for="field-{$i->network_username}-privacy-private" data-check-field="field-{$i->network_username}-privacy-public"><i class="fa fa-lock icon"></i><span class="text">Just you</span></label>
+
+            <input type="radio" name="{$i->network_username}-privacy-toggle-control" value="1"
+            class="field-privacy-public"
+            {if $i->is_public}checked="checked"{/if} id="field-{$i->network_username}-privacy-public" /><label class="toggle-label" for="field-{$i->network_username}-privacy-public" data-check-field="field-{$i->network_username}-privacy-private"><i class="fa fa-globe icon"></i><span class="text">Everyone</span></label>
+          </div>
         </div>
-        {if $user_is_admin}
-        <div class="span3">
-            <span id="divactivate{$i->id}"><input type="submit" name="submit" id="{$i->id}" class="btn {if $i->is_active}btnPause{else}btnPlay{/if}" value="{if $i->is_active}Pause{else}Start{/if} crawling" /></span>
+
+        {if $user_is_admin and !isset($thinkupllc_endpoint)}
+        <div class="extra-buttons">
+            <span id="divactivate{$i->id}"><input type="submit" name="submit" id="{$i->id}" class="btn btn-default {if $i->is_active}btnPause{else}btnPlay{/if} btn-sm" value="{if $i->is_active}Pause{else}Start{/if} crawling" /></span>
         </div>
         {/if}
-        <div class="span3">
-            <span id="delete{$i->id}"><form method="post" action="{$site_root_path}account/?p=instagram"><input type="hidden" name="instance_id" value="{$i->id}">
-            {insert name="csrf_token"}<!-- delete account csrf token -->
-            <input onClick="return confirm('Do you really want to delete this Instagram account from ThinkUp?');"  type="submit" name="action" class="btn btn-danger" value="Delete" /></form></span>
+
+        <div class="account-action account-action-delete">
+          <form method="post" action="{$site_root_path}account/?p=instagram"
+            name="{$i->network_username}-delete" class="">
+          <input type="hidden" name="instance_id" value="{$i->id}">
+          <input type="hidden" name="action" value="Delete">
+          {insert name="csrf_token"}
+          <a href="javascript:document.forms['{$i->network_username}-delete'].submit();"
+            onClick="return confirm('Do you really want to delete the {$i->network_username} account?');">
+            <i class="fa fa-minus-circle icon"></i>
+          </a>
+          </form>
         </div>
+      </li>
+      {/foreach}
+    </ul>
+    {/if}
+
+
+    <div class="account-buttons">
+      {if $instaconnect_link}
+        {include file="_usermessage.tpl" field="authorization"}
+        <a class="btn btn-default btn-account-add" href="{$instaconnect_link}"><i class="fa fa-instagram icon"></i>Connect an Instagram account</a>
+      {/if}
+      {if $instaconnect_link and count($instances) > 0}<br>{/if}
+      {if count($instances) > 0 }
+      <button class="btn btn-transparent btn-account-remove"
+      data-label-visible="Cancel account removal" data-label-hidden="Remove an account">Remove an account</button>
+      {/if}
     </div>
-    {/foreach}
+
+    <div class="form-notes">
+      {if $instaconnect_link}<p class="accounts-privacy">ThinkUp will never post on your behalf.</p>{/if}
+
+      {if isset($thinkupllc_endpoint)}
+      {include file="_usermessage.tpl" field="membership_cap"}
+      {/if}
+    </div>
+
+  {if !isset($thinkupllc_endpoint)}
+  <div id="contact-admin-div" style="display: none;">
+  {include file="_plugin.admin-request.tpl"}
+  </div>
+
+  {if $user_is_admin}
+  {include file="_plugin.showhider.tpl"}
+  {include file="_usermessage.tpl" field="setup"}
+
+  <p style="padding:5px">To set up the Instagram plugin:</p>
+  <ol style="margin-left:40px">
+  <li><a href="http://instagram.com/developer/clients/manage/" target="_blank" style="text-decoration: underline;">Go to the Instagram Developers Clients page</a> and click the "Register a new Client" button.</li>
+  <li>
+      In "Application Name", copy and paste the following:<br />
+      <small>
+        <code style="font-family:Courier;" id="clippy_2987">{$logged_in_user} ThinkUp</code>
+      </small>
+      <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+                width="100"
+                height="14"
+                class="clippy"
+                id="clippy" >
+        <param name="movie" value="{$site_root_path}assets/flash/clippy.swf"/>
+        <param name="allowScriptAccess" value="always" />
+        <param name="quality" value="high" />
+        <param name="scale" value="noscale" />
+        <param NAME="FlashVars" value="id=clippy_2987&amp;copied=copied!&amp;copyto=copy to clipboard">
+        <param name="bgcolor" value="#FFFFFF">
+        <param name="wmode" value="opaque">
+        <embed src="{$site_root_path}assets/flash/clippy.swf"
+               width="100"
+               height="14"
+               name="clippy"
+               quality="high"
+               allowScriptAccess="always"
+               type="application/x-shockwave-flash"
+               pluginspage="http://www.macromedia.com/go/getflashplayer"
+               FlashVars="id=clippy_2987&amp;copied=copied!&amp;copyto=copy to clipboard"
+               bgcolor="#FFFFFF"
+               wmode="opaque"
+        />
+      </object><br />
+  </li>
+  <li>
+      In "Description", enter  <span style="font-family:Courier;">ThinkUp Instagram access</span><br />
+  </li>
+  <li>
+      In "Website", put <span style="font-family:Courier;">{$thinkup_site_url}</span><br />
+  </li>
+  <li>
+    In "OAuth redirect_uri", copy and paste the following:<br>
+      <small>
+        <code style="font-family:Courier;" id="clippy_2988">{$thinkup_site_url}account/?p=instagram</code>
+      </small>
+      <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+                width="100"
+                height="14"
+                class="clippy"
+                id="clippy" >
+        <param name="movie" value="{$site_root_path}assets/flash/clippy.swf"/>
+        <param name="allowScriptAccess" value="always" />
+        <param name="quality" value="high" />
+        <param name="scale" value="noscale" />
+        <param NAME="FlashVars" value="id=clippy_2988&amp;copied=copied!&amp;copyto=copy to clipboard">
+        <param name="bgcolor" value="#FFFFFF">
+        <param name="wmode" value="opaque">
+        <embed src="{$site_root_path}assets/flash/clippy.swf"
+               width="100"
+               height="14"
+               name="clippy"
+               quality="high"
+               allowScriptAccess="always"
+               type="application/x-shockwave-flash"
+               pluginspage="http://www.macromedia.com/go/getflashplayer"
+               FlashVars="id=clippy_2988&amp;copied=copied!&amp;copyto=copy to clipboard"
+               bgcolor="#FFFFFF"
+               wmode="opaque"
+        />
+      </object><br />
+      Click on "Save Changes".
+  </li>
+  <li>Enter the Instagram-provided <strong>Client ID</strong> and <strong>Client Secret</strong> here.</li>
+  </ol>
+
+  {/if}
+
+
+  {if $options_markup}
+  <p>
+  {$options_markup}
+  </p>
+  {/if}
+
+  {if $user_is_admin}</div>{/if}
+
+  {/if}
+
 </div>
-{/if}
-
-<div id="contact-admin-div" style="display: none;">
-{include file="_plugin.admin-request.tpl"}
-</div>
-
-{if $user_is_admin}
-{include file="_plugin.showhider.tpl"}
-{include file="_usermessage.tpl" field="setup"}
-
-<p style="padding:5px">To set up the Instagram plugin:</p>
-<ol style="margin-left:40px">
-<li><a href="http://instagram.com/developer/clients/manage/" target="_blank" style="text-decoration: underline;">Go to the Instagram Developers Clients page</a> and click the "Register a new Client" button.</li>
-<li>
-    In "Application Name", copy and paste the following:<br />
-    <small>
-      <code style="font-family:Courier;" id="clippy_2987">{$logged_in_user} ThinkUp</code>
-    </small>
-    <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
-              width="100"
-              height="14"
-              class="clippy"
-              id="clippy" >
-      <param name="movie" value="{$site_root_path}assets/flash/clippy.swf"/>
-      <param name="allowScriptAccess" value="always" />
-      <param name="quality" value="high" />
-      <param name="scale" value="noscale" />
-      <param NAME="FlashVars" value="id=clippy_2987&amp;copied=copied!&amp;copyto=copy to clipboard">
-      <param name="bgcolor" value="#FFFFFF">
-      <param name="wmode" value="opaque">
-      <embed src="{$site_root_path}assets/flash/clippy.swf"
-             width="100"
-             height="14"
-             name="clippy"
-             quality="high"
-             allowScriptAccess="always"
-             type="application/x-shockwave-flash"
-             pluginspage="http://www.macromedia.com/go/getflashplayer"
-             FlashVars="id=clippy_2987&amp;copied=copied!&amp;copyto=copy to clipboard"
-             bgcolor="#FFFFFF"
-             wmode="opaque"
-      />
-    </object><br />
-</li>
-<li>
-    In "Description", enter  <span style="font-family:Courier;">ThinkUp Instagram access</span><br />
-</li>
-<li>
-    In "Website", put <span style="font-family:Courier;">{$thinkup_site_url}</span><br />
-</li>
-<li>
-  In "OAuth redirect_uri", copy and paste the following:<br>
-    <small>
-      <code style="font-family:Courier;" id="clippy_2988">{$thinkup_site_url}account/?p=instagram</code>
-    </small>
-    <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
-              width="100"
-              height="14"
-              class="clippy"
-              id="clippy" >
-      <param name="movie" value="{$site_root_path}assets/flash/clippy.swf"/>
-      <param name="allowScriptAccess" value="always" />
-      <param name="quality" value="high" />
-      <param name="scale" value="noscale" />
-      <param NAME="FlashVars" value="id=clippy_2988&amp;copied=copied!&amp;copyto=copy to clipboard">
-      <param name="bgcolor" value="#FFFFFF">
-      <param name="wmode" value="opaque">
-      <embed src="{$site_root_path}assets/flash/clippy.swf"
-             width="100"
-             height="14"
-             name="clippy"
-             quality="high"
-             allowScriptAccess="always"
-             type="application/x-shockwave-flash"
-             pluginspage="http://www.macromedia.com/go/getflashplayer"
-             FlashVars="id=clippy_2988&amp;copied=copied!&amp;copyto=copy to clipboard"
-             bgcolor="#FFFFFF"
-             wmode="opaque"
-      />
-    </object><br />
-    Click on "Save Changes".
-</li>
-<li>Enter the Instagram-provided <strong>Client ID</strong> and <strong>Client Secret</strong> here.</li>
-</ol>
-
-{/if}
 
 
-{if $options_markup}
-<p>
-{$options_markup}
-</p>
-{/if}
-
-{if $user_is_admin}</div>{/if}
-
-{literal}
-<script type="text/javascript">
-if( required_values_set ) {
-    $('#add-account-div').show();
-} else {
-    if(! is_admin) {
-        $('#contact-admin-div').show();
-    }
-}
-{/literal}
-</script>


### PR DESCRIPTION
Basic Instagram support. Restyle plugin settings/config page, add IG to navigation, enable inline display of images in posts, and correct display of Instagram icon in insight footers. And update tests, of course. Everything except new IG insights and IG promotion in blank state for users.